### PR TITLE
Ensure that urls longer than the page width are broken up

### DIFF
--- a/thesis-style/thesis.tex
+++ b/thesis-style/thesis.tex
@@ -25,6 +25,8 @@
 \usepackage{hyperref}
 
 % Ensure that urls longer than the page width are broken up
+% Based on the answer of StackOverflow user "xamde":
+% https://tex.stackexchange.com/a/10401/155506
 \expandafter\def\expandafter\UrlBreaks\expandafter{\UrlBreaks%  save the current one
   \do\a\do\b\do\c\do\d\do\e\do\f\do\g\do\h\do\i\do\j%
   \do\k\do\l\do\m\do\n\do\o\do\p\do\q\do\r\do\s\do\t%

--- a/thesis-style/thesis.tex
+++ b/thesis-style/thesis.tex
@@ -24,6 +24,15 @@
 
 \usepackage{hyperref}
 
+% Ensure that urls longer than the page width are broken up
+\expandafter\def\expandafter\UrlBreaks\expandafter{\UrlBreaks%  save the current one
+  \do\a\do\b\do\c\do\d\do\e\do\f\do\g\do\h\do\i\do\j%
+  \do\k\do\l\do\m\do\n\do\o\do\p\do\q\do\r\do\s\do\t%
+  \do\u\do\v\do\w\do\x\do\y\do\z\do\A\do\B\do\C\do\D%
+  \do\E\do\F\do\G\do\H\do\I\do\J\do\K\do\L\do\M\do\N%
+  \do\O\do\P\do\Q\do\R\do\S\do\T\do\U\do\V\do\W\do\X%
+  \do\Y\do\Z}
+
 %---------------------------------------------------------------------%
 %                     Options                                         %    
 %---------------------------------------------------------------------%


### PR DESCRIPTION
I added some footnotes to my thesis and discovered that urls longer than the page width were overflowing. Per https://tex.stackexchange.com/a/10401 the solution was to enforce breaks after each possible character in an URL.