### PR TITLE
Enable \citeauthor to be used for citations

### DIFF
--- a/thesis-style/thesis.tex
+++ b/thesis-style/thesis.tex
@@ -24,6 +24,9 @@
 
 \usepackage{hyperref}
 
+% Used in the bibliography to enable \citeauthor{citation}
+\usepackage[numbers]{natbib}
+
 %---------------------------------------------------------------------%
 %                     Options                                         %    
 %---------------------------------------------------------------------%
@@ -94,7 +97,7 @@ ThePlace, the Netherlands\\
 \include{related_work} 
 \include{conclusions_and_future_work} 
 
-\bibliographystyle{plain}
+\bibliographystyle{plainnat}
 \bibliography{thesis}
 
 \appendix


### PR DESCRIPTION
Per https://tex.stackexchange.com/a/69381/155506 using `plainnat` of the `natbib` package makes `\citeauthor{citation}` work. By specifying `[numbers]` on the package statement, there is no visual difference in the actual bibliography and we remain using numbered citations.

CC @Keraito You probably want this as well