### PR TITLE
Add example for specifying research questions

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -21,6 +21,10 @@ The research questions investigated in this thesis are:
 \begin{enumerate}[label=\textbf{RQ\arabic*}]
 \item How should I use this thesis template style?
 \item How can I import this thesis style into ShareLatex?
+\begin{enumerate}[label*=\textbf{.\arabic*}]
+\item Where is the source code of the template located?
+\item How do I retrieve the source code?
+\end{enumerate}
 \item Any other question you can think of?
 \end{enumerate}
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -5,18 +5,23 @@ motivations of the graduate project. We will describe \ldots
 
 \section{Terminology}
 
-The term \emph{reverse engineering} is defined by Chikofsky and Cross as 
-``\emph{The process of analyzing a subject system with two goals in mind: 
+The term \emph{reverse engineering} is defined by Chikofsky and Cross as
+``\emph{The process of analyzing a subject system with two goals in mind:
 (1) to identify the system's components and their interrelationships; and,
-(2) to create representations of the system in another form or at a higher 
+(2) to create representations of the system in another form or at a higher
 level of abstraction}'' \cite{CC90}.
 
-Note that this Terminology section is not a required section but 
+Note that this Terminology section is not a required section but
 merely an example.
 
 \section{Research Question(s)}
 
-The research question investigated in this thesis is \ldots
+The research questions investigated in this thesis are:
+
+\begin{enumerate}[label=\textbf{RQ\arabic*}]
+\item How should I use this thesis template style?
+\item How can I import this thesis style into ShareLatex?
+\item Any other question you can think of?
+\end{enumerate}
 
 \lipsum{10} % add some pseudo content
-

--- a/thesis.tex
+++ b/thesis.tex
@@ -9,7 +9,7 @@
 % %% The package 'algorithm' is useful, but incompatible with memoir.
 % %% Cor-Paul Bezemer / http://homes.esat.kuleuven.be/~dvherten/esatthesis.html
 % %% suggest the following fix:
-\let\newfloat\undefined \usepackage{algorithmic} 
+\let\newfloat\undefined \usepackage{algorithmic}
 \usepackage{algorithm}
 
 % Include right (LaTeX/PDFLaTeX) graphics package
@@ -23,6 +23,7 @@
 %\fi
 
 \usepackage{hyperref}
+\usepackage{enumitem}
 
 % Used in the bibliography to enable \citeauthor{citation}
 \usepackage[numbers]{natbib}
@@ -39,15 +40,15 @@
   \do\Y\do\Z}
 
 %---------------------------------------------------------------------%
-%                     Options                                         %    
+%                     Options                                         %
 %---------------------------------------------------------------------%
 
 \title{Software Engineering Research Group \\MSc Thesis Style}
 \subtitle{Version of \today}
 % The final version of your thesis should typically use a different
 % subtitle without the current date, for example
-%\subtitle{Master's Thesis} 
-% or remove the subtitle by uncommenting the following line: 
+%\subtitle{Master's Thesis}
+% or remove the subtitle by uncommenting the following line:
 %\subtitle{}
 
 \author{Leon Moonen}                               % CHANGE TO YOUR NAME
@@ -74,7 +75,7 @@ ThePlace, the Netherlands\\
 \colophon{\noindent
   \copyright{} \the\year \: \theauthor. \emph{Note that this notice is for demonstration
   purposes and that the \LaTeX{} style and document source are free to
-  use as basis for your MSc thesis.} \\[1em] 
+  use as basis for your MSc thesis.} \\[1em]
   Cover picture: A ``random'' maze generated in postscript.
 }
 
@@ -103,10 +104,10 @@ ThePlace, the Netherlands\\
 \cleardoublepage\listoffigures
 \cleardoublepage\mainmatter
 
-\include{introduction} 
-\include{chapter} 
-\include{related_work} 
-\include{conclusions_and_future_work} 
+\include{introduction}
+\include{chapter}
+\include{related_work}
+\include{conclusions_and_future_work}
 
 \bibliographystyle{plainnat}
 \bibliography{thesis}


### PR DESCRIPTION
Using the package `enumitem` we can standardize the way research questions are shown:
![image](https://user-images.githubusercontent.com/5948271/39185025-f8888660-47c5-11e8-91db-ff03d73e1fb4.png)
